### PR TITLE
Detect validation rules

### DIFF
--- a/src/ProvidesValidationRules.php
+++ b/src/ProvidesValidationRules.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * This file is part of event-engine/php-json-schema.
+ * (c) 2018-2019 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace EventEngine\JsonSchema;
+
+interface ProvidesValidationRules
+{
+    public static function validationRules(): array;
+}

--- a/src/RecordLogic/TypeDetector.php
+++ b/src/RecordLogic/TypeDetector.php
@@ -28,7 +28,8 @@ final class TypeDetector
         }
 
         if($refObj->implementsInterface(JsonSchemaAwareCollection::class)) {
-            return JsonSchema::array(\call_user_func([$classOrType, '__itemSchema']));
+            $validation = is_callable([$classOrType, 'validationRules'])? \call_user_func([$classOrType, 'validationRules']) : null;
+            return JsonSchema::array(\call_user_func([$classOrType, '__itemSchema']), $validation);
         }
 
         if($scalarSchemaType = self::determineScalarTypeIfPossible($classOrType)) {
@@ -41,15 +42,18 @@ final class TypeDetector
     private static function determineScalarTypeIfPossible(string $class): ?Type
     {
         if(is_callable([$class, 'fromString'])) {
-            return JsonSchema::string();
+            $validation = is_callable([$class, 'validationRules'])? \call_user_func([$class, 'validationRules']) : null;
+            return JsonSchema::string($validation);
         }
 
         if(is_callable([$class, 'fromInt'])) {
-            return JsonSchema::integer();
+            $validation = is_callable([$class, 'validationRules'])? \call_user_func([$class, 'validationRules']) : null;
+            return JsonSchema::integer($validation);
         }
 
         if(is_callable([$class, 'fromFloat'])) {
-            return JsonSchema::float();
+            $validation = is_callable([$class, 'validationRules'])? \call_user_func([$class, 'validationRules']) : null;
+            return JsonSchema::float($validation);
         }
 
         if(is_callable([$class, 'fromBool'])) {

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -13,6 +13,7 @@ namespace EventEngine\JsonSchema\Type;
 
 use EventEngine\JsonSchema\AnnotatedType;
 use EventEngine\JsonSchema\JsonSchema;
+use EventEngine\JsonSchema\Type;
 use EventEngine\Schema\PayloadSchema;
 use EventEngine\Schema\TypeSchema;
 
@@ -20,6 +21,11 @@ final class ArrayType implements AnnotatedType, PayloadSchema
 {
     use NullableType,
         HasAnnotations;
+
+    public const MAX_ITEMS = 'maxItems';
+    public const MIN_ITEMS = 'minItems';
+    public const UNIQUE_ITEMS = 'uniqueItems';
+    public const CONTAINS = 'contains';
 
     /**
      * @var string|array
@@ -40,6 +46,58 @@ final class ArrayType implements AnnotatedType, PayloadSchema
     {
         $this->itemSchema = $itemSchema;
         $this->validation = $validation;
+    }
+
+    public function withMaxItems(int $maxItems): self
+    {
+        $cp = clone $this;
+
+        $validation = (array) $this->validation;
+
+        $validation[self::MAX_ITEMS] = $maxItems;
+
+        $cp->validation = $validation;
+
+        return $cp;
+    }
+
+    public function withMinItems(int $minItems): self
+    {
+        $cp = clone $this;
+
+        $validation = (array) $this->validation;
+
+        $validation[self::MIN_ITEMS] = $minItems;
+
+        $cp->validation = $validation;
+
+        return $cp;
+    }
+
+    public function withUniqueItems(): self
+    {
+        $cp = clone $this;
+
+        $validation = (array) $this->validation;
+
+        $validation[self::UNIQUE_ITEMS] = true;
+
+        $cp->validation = $validation;
+
+        return $cp;
+    }
+
+    public function withContains(TypeSchema $itemSchema): self
+    {
+        $cp = clone $this;
+
+        $validation = (array) $this->validation;
+
+        $validation[self::CONTAINS] = $itemSchema->toArray();
+
+        $cp->validation = $validation;
+
+        return $cp;
     }
 
     public function toArray(): array

--- a/src/Type/BoolType.php
+++ b/src/Type/BoolType.php
@@ -19,6 +19,8 @@ final class BoolType implements AnnotatedType
     use NullableType,
         HasAnnotations;
 
+    public const CONST = 'const';
+
     /**
      * @var string|array
      */

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -19,6 +19,14 @@ class FloatType implements AnnotatedType
     use NullableType,
         HasAnnotations;
 
+    public const MINIMUM = 'minimum';
+    public const MAXIMUM = 'maximum';
+    public const MULTIPLE_OF = 'multipleOf';
+    public const EXCLUSIVE_MAXIMUM = 'exclusiveMaximum';
+    public const EXCLUSIVE_MINIMUM = 'exclusiveMinimum';
+    public const ENUM = 'enum';
+    public const CONST = 'const';
+
     /**
      * @var string|array
      */
@@ -45,7 +53,20 @@ class FloatType implements AnnotatedType
 
         $validation = (array) $this->validation;
 
-        $validation['minimum'] = $min;
+        $validation[self::MINIMUM] = $min;
+
+        $cp->validation = $validation;
+
+        return $cp;
+    }
+
+    public function withExclusiveMinimum(float $exclusiveMin): self
+    {
+        $cp = clone $this;
+
+        $validation = (array) $this->validation;
+
+        $validation[self::EXCLUSIVE_MINIMUM] = $exclusiveMin;
 
         $cp->validation = $validation;
 
@@ -58,7 +79,20 @@ class FloatType implements AnnotatedType
 
         $validation = (array) $this->validation;
 
-        $validation['maximum'] = $max;
+        $validation[self::MAXIMUM] = $max;
+
+        $cp->validation = $validation;
+
+        return $cp;
+    }
+
+    public function withExclusiveMaximum(float $exclusiveMax): self
+    {
+        $cp = clone $this;
+
+        $validation = (array) $this->validation;
+
+        $validation[self::EXCLUSIVE_MAXIMUM] = $exclusiveMax;
 
         $cp->validation = $validation;
 
@@ -71,8 +105,21 @@ class FloatType implements AnnotatedType
 
         $validation = (array) $this->validation;
 
-        $validation['minimum'] = $min;
-        $validation['maximum'] = $max;
+        $validation[self::MINIMUM] = $min;
+        $validation[self::MAXIMUM] = $max;
+
+        $cp->validation = $validation;
+
+        return $cp;
+    }
+
+    public function withMultipleOf(float $multipleOf): self
+    {
+        $cp = clone $this;
+
+        $validation = (array) $this->validation;
+
+        $validation[self::MULTIPLE_OF] = $multipleOf;
 
         $cp->validation = $validation;
 

--- a/src/Type/IntType.php
+++ b/src/Type/IntType.php
@@ -19,6 +19,15 @@ class IntType implements AnnotatedType
     use NullableType,
         HasAnnotations;
 
+    public const MINIMUM = 'minimum';
+    public const MAXIMUM = 'maximum';
+    public const MULTIPLE_OF = 'multipleOf';
+    public const EXCLUSIVE_MAXIMUM = 'exclusiveMaximum';
+    public const EXCLUSIVE_MINIMUM = 'exclusiveMinimum';
+    public const ENUM = 'enum';
+    public const CONST = 'const';
+
+
     /**
      * @var string|array
      */
@@ -45,7 +54,20 @@ class IntType implements AnnotatedType
 
         $validation = (array) $this->validation;
 
-        $validation['minimum'] = $min;
+        $validation[self::MINIMUM] = $min;
+
+        $cp->validation = $validation;
+
+        return $cp;
+    }
+
+    public function withExclusiveMinimum(int $exclusiveMin): self
+    {
+        $cp = clone $this;
+
+        $validation = (array) $this->validation;
+
+        $validation[self::EXCLUSIVE_MINIMUM] = $exclusiveMin;
 
         $cp->validation = $validation;
 
@@ -58,7 +80,20 @@ class IntType implements AnnotatedType
 
         $validation = (array) $this->validation;
 
-        $validation['maximum'] = $max;
+        $validation[self::MAXIMUM] = $max;
+
+        $cp->validation = $validation;
+
+        return $cp;
+    }
+
+    public function withExclusiveMaximum(int $exclusiveMax): self
+    {
+        $cp = clone $this;
+
+        $validation = (array) $this->validation;
+
+        $validation[self::EXCLUSIVE_MAXIMUM] = $exclusiveMax;
 
         $cp->validation = $validation;
 
@@ -71,8 +106,21 @@ class IntType implements AnnotatedType
 
         $validation = (array) $this->validation;
 
-        $validation['minimum'] = $min;
-        $validation['maximum'] = $max;
+        $validation[self::MINIMUM] = $min;
+        $validation[self::MAXIMUM] = $max;
+
+        $cp->validation = $validation;
+
+        return $cp;
+    }
+
+    public function withMultipleOf(float $multipleOf): self
+    {
+        $cp = clone $this;
+
+        $validation = (array) $this->validation;
+
+        $validation[self::MULTIPLE_OF] = $multipleOf;
 
         $cp->validation = $validation;
 

--- a/src/Type/StringType.php
+++ b/src/Type/StringType.php
@@ -19,6 +19,14 @@ class StringType implements AnnotatedType
     use NullableType,
         HasAnnotations;
 
+    public const PATTERN = 'pattern';
+    public const FORMAT = 'format';
+    public const MIN_LENGTH = 'minLength';
+    public const MAX_LENGTH = 'maxLength';
+    public const ENUM = 'enum';
+    public const CONST = 'const';
+
+
     private $type = JsonSchema::TYPE_STRING;
 
     /**
@@ -34,7 +42,15 @@ class StringType implements AnnotatedType
     public function withMinLength(int $minLength): self
     {
         $cp = clone $this;
-        $cp->validation['minLength'] = $minLength;
+        $cp->validation[self::MIN_LENGTH] = $minLength;
+
+        return $cp;
+    }
+
+    public function withMaxLength(int $maxLength): self
+    {
+        $cp = clone $this;
+        $cp->validation[self::MAX_LENGTH] = $maxLength;
 
         return $cp;
     }
@@ -42,7 +58,7 @@ class StringType implements AnnotatedType
     public function withPattern(string $pattern): self
     {
         $cp = clone $this;
-        $cp->validation['pattern'] = $pattern;
+        $cp->validation[self::PATTERN] = $pattern;
 
         return $cp;
     }

--- a/tests/JsonSchemaAwareRecordLogicTest.php
+++ b/tests/JsonSchemaAwareRecordLogicTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace EventEngineTest\JsonSchema;
 
 use EventEngine\JsonSchema\JsonSchema;
-use EventEngine\JsonSchema\Type\TypeRef;
 use EventEngineTest\JsonSchema\Stub\ArrayItemRecord;
 use EventEngineTest\JsonSchema\Stub\CollectionItemAllowNestedRecord;
 use EventEngineTest\JsonSchema\Stub\CollectionItemRecord;
@@ -13,6 +12,7 @@ use EventEngineTest\JsonSchema\Stub\NullableArrayItemRecordRecord;
 use EventEngineTest\JsonSchema\Stub\NullableScalarPropsRecord;
 use EventEngineTest\JsonSchema\Stub\ScalarPropsRecord;
 use EventEngineTest\JsonSchema\Stub\VoOptionalPropsRecord;
+use EventEngineTest\JsonSchema\Stub\VoProp\UserId;
 use EventEngineTest\JsonSchema\Stub\VoPropsRecord;
 
 final class JsonSchemaAwareRecordLogicTest extends BasicTestCase
@@ -100,7 +100,7 @@ final class JsonSchemaAwareRecordLogicTest extends BasicTestCase
         $schema = CollectionItemRecord::__schema();
 
         $expected = JsonSchema::object([
-            'friends' => JsonSchema::array(JsonSchema::typeRef(ScalarPropsRecord::__type()))
+            'friends' => JsonSchema::array(JsonSchema::typeRef(ScalarPropsRecord::__type()))->withMaxItems(10)
         ]);
 
         $this->assertEquals($expected->toArray(), $schema->toArray());
@@ -127,10 +127,10 @@ final class JsonSchemaAwareRecordLogicTest extends BasicTestCase
         $schema = VoPropsRecord::__schema();
 
         $expected = JsonSchema::object([
-            'userId' => JsonSchema::string(),
-            'age' => JsonSchema::integer(),
+            'userId' => JsonSchema::string()->withPattern(UserId::PATTERN),
+            'age' => JsonSchema::integer()->withRange(0, 150),
             'member' => JsonSchema::boolean(),
-            'score' => JsonSchema::float()
+            'score' => JsonSchema::float()->withRange(0.1, 1),
         ]);
 
         $this->assertEquals($expected->toArray(), $schema->toArray());
@@ -144,11 +144,11 @@ final class JsonSchemaAwareRecordLogicTest extends BasicTestCase
         $schema = VoOptionalPropsRecord::__schema();
 
         $expected = JsonSchema::object([
-            'userId' => JsonSchema::string(),
-            'age' => JsonSchema::integer(),
+            'userId' => JsonSchema::string()->withPattern(UserId::PATTERN),
+            'age' => JsonSchema::integer()->withRange(0, 150),
             'member' => JsonSchema::boolean(),
         ], [
-            'score' => JsonSchema::float()
+            'score' => JsonSchema::float()->withRange(0.1, 1),
         ]);
 
         $this->assertEquals($expected->toArray(), $schema->toArray());

--- a/tests/Stub/ScalarPropsRecordCollection.php
+++ b/tests/Stub/ScalarPropsRecordCollection.php
@@ -5,14 +5,21 @@ namespace EventEngineTest\JsonSchema\Stub;
 
 use EventEngine\JsonSchema\JsonSchemaAwareCollection;
 use EventEngine\JsonSchema\JsonSchemaAwareCollectionLogic;
+use EventEngine\JsonSchema\ProvidesValidationRules;
+use EventEngine\JsonSchema\Type\ArrayType;
 
-final class ScalarPropsRecordCollection implements JsonSchemaAwareCollection
+final class ScalarPropsRecordCollection implements JsonSchemaAwareCollection, ProvidesValidationRules
 {
     use JsonSchemaAwareCollectionLogic;
 
     private static function __itemType(): ?string
     {
         return ScalarPropsRecord::class;
+    }
+
+    public static function validationRules(): array
+    {
+        return [ArrayType::MAX_ITEMS => 10];
     }
 
     /**

--- a/tests/Stub/VoProp/Age.php
+++ b/tests/Stub/VoProp/Age.php
@@ -3,9 +3,17 @@ declare(strict_types=1);
 
 namespace EventEngineTest\JsonSchema\Stub\VoProp;
 
-final class Age
+use EventEngine\JsonSchema\ProvidesValidationRules;
+use EventEngine\JsonSchema\Type\IntType;
+
+final class Age implements ProvidesValidationRules
 {
     private $age;
+
+    public static function validationRules(): array
+    {
+        return [IntType::MINIMUM => 0, IntType::MAXIMUM => 150];
+    }
 
     public static function fromInt(int $age): self
     {
@@ -35,5 +43,4 @@ final class Age
     {
         return (string)$this->age;
     }
-
 }

--- a/tests/Stub/VoProp/Score.php
+++ b/tests/Stub/VoProp/Score.php
@@ -3,9 +3,17 @@ declare(strict_types=1);
 
 namespace EventEngineTest\JsonSchema\Stub\VoProp;
 
-final class Score
+use EventEngine\JsonSchema\ProvidesValidationRules;
+use EventEngine\JsonSchema\Type\FloatType;
+
+final class Score implements ProvidesValidationRules
 {
     private $score;
+
+    public static function validationRules(): array
+    {
+        return [FloatType::MINIMUM => 0.1, FloatType::MAXIMUM => 1];
+    }
 
     public static function fromFloat(float $score): self
     {
@@ -35,5 +43,4 @@ final class Score
     {
         return (string)$this->score;
     }
-
 }

--- a/tests/Stub/VoProp/UserId.php
+++ b/tests/Stub/VoProp/UserId.php
@@ -3,9 +3,18 @@ declare(strict_types=1);
 
 namespace EventEngineTest\JsonSchema\Stub\VoProp;
 
-final class UserId
+use EventEngine\JsonSchema\ProvidesValidationRules;
+
+final class UserId implements ProvidesValidationRules
 {
+    public const PATTERN = '^[0-9]+$';
+
     private $userId;
+
+    public static function validationRules(): array
+    {
+        return ['pattern' => self::PATTERN];
+    }
 
     public static function fromString(string $userId): self
     {


### PR DESCRIPTION
The `TypeDetector` now checks if the type class provides validation rules. The rules are added to the type json schema.

I've also added constants for all possible validation keys and some missing `with*` methods.