### PR TITLE
enable multiple types for enum

### DIFF
--- a/src/JsonSchema.php
+++ b/src/JsonSchema.php
@@ -17,8 +17,10 @@ use EventEngine\JsonSchema\Type\BoolType;
 use EventEngine\JsonSchema\Type\EmailType;
 use EventEngine\JsonSchema\Type\EnumType;
 use EventEngine\JsonSchema\Type\FloatType;
+use EventEngine\JsonSchema\Type\IntEnumType;
 use EventEngine\JsonSchema\Type\IntType;
 use EventEngine\JsonSchema\Type\ObjectType;
+use EventEngine\JsonSchema\Type\StringEnumType;
 use EventEngine\JsonSchema\Type\StringType;
 use EventEngine\JsonSchema\Type\TypeRef;
 use EventEngine\JsonSchema\Type\UnionType;
@@ -105,9 +107,20 @@ final class JsonSchema
         return new BoolType();
     }
 
-    public static function enum(array $entries): EnumType
+    public static function enum(array $entries, string $type = JsonSchema::TYPE_STRING): EnumType
     {
-        return new EnumType(...$entries);
+        switch($type) {
+            case JsonSchema::TYPE_STRING:
+                $class = StringEnumType::class;
+                break;
+            case JsonSchema::TYPE_INT:
+                $class = IntEnumType::class;
+                break;
+            default:
+                $class = EnumType::class;
+        }
+
+        return new $class(...$entries);
     }
 
     public static function nullOr(Type $schema): Type

--- a/src/Type/EnumType.php
+++ b/src/Type/EnumType.php
@@ -23,12 +23,12 @@ class EnumType implements AnnotatedType
     /**
      * @var string|array
      */
-    private $type = JsonSchema::TYPE_STRING;
+    protected $type = JsonSchema::TYPE_STRING;
 
     /**
      * @var string[]
      */
-    private $entries;
+    protected $entries;
 
     public function __construct(string ...$entries)
     {

--- a/src/Type/IntEnumType.php
+++ b/src/Type/IntEnumType.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventEngine\JsonSchema\Type;
+
+use EventEngine\JsonSchema\JsonSchema;
+
+class IntEnumType extends EnumType
+{
+    /**
+     * @var string|array
+     */
+    protected $type = JsonSchema::TYPE_INT;
+
+    /**
+     * @var int[]
+     */
+    protected $entries;
+
+    public function __construct(int ...$entries)
+    {
+        $this->entries = $entries;
+    }
+}

--- a/src/Type/StringEnumType.php
+++ b/src/Type/StringEnumType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventEngine\JsonSchema\Type;
+
+use EventEngine\JsonSchema\JsonSchema;
+
+class StringEnumType extends EnumType
+{
+    /**
+     * @var string|array
+     */
+    protected $type = JsonSchema::TYPE_STRING;
+}

--- a/tests/Type/EnumTypeTest.php
+++ b/tests/Type/EnumTypeTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace EventEngineTest\JsonSchema\Type;
 
+use EventEngine\JsonSchema\JsonSchema;
 use EventEngine\JsonSchema\Type\EnumType;
 use EventEngineTest\JsonSchema\BasicTestCase;
 
@@ -43,6 +44,41 @@ final class EnumTypeTest extends BasicTestCase
             [
                 'type' => ['string', 'null'],
                 'enum' => ['a', 'b', null]
+            ],
+            $enumType->toArray()
+        );
+    }
+
+
+    /**
+     * @test
+     */
+    public function it_creates_int_enum_type()
+    {
+        $enumType = JsonSchema::enum([0, 1], JsonSchema::TYPE_INT);
+
+        $this->assertEquals(
+            [
+                'type' => 'integer',
+                'enum' => [0, 1],
+            ],
+            $enumType->toArray()
+        );
+    }
+
+
+    /**
+     * @test
+     */
+    public function it_creates_int_nullable_enum_type()
+    {
+        $enumType = JsonSchema::enum([0, 1], JsonSchema::TYPE_INT)
+            ->asNullable();
+
+        $this->assertEquals(
+            [
+                'type' => ['integer', 'null'],
+                'enum' => [0, 1, null]
             ],
             $enumType->toArray()
         );


### PR DESCRIPTION
Enum now only allows string as a type.

This PR allows you to change the type of the enum. I'll had to make it backwards compatible, so I didn't change the constructor: I used a setter (setType) instead of passing the type as an extra constructor parameter. It was also impossible to add an extra parameter because of the spread parameter (...entries).

Instead I'll just cast the entries while changing the type.